### PR TITLE
Return ready battle inline so replays survive blob CDN warmup

### DIFF
--- a/api/battles/index.js
+++ b/api/battles/index.js
@@ -12,6 +12,7 @@ const {
   buildBattleParticipant,
   buildGeneratingBattleRecord,
   createBattleSimulation,
+  formatBattleResponse,
   resolveAttackerParticipant,
 } = require("../_lib/battle");
 const {
@@ -328,8 +329,9 @@ module.exports = async (req, res) => {
 
     json(res, 200, {
       battleId,
-      status: "generating",
+      status: "ready",
       reveal,
+      battle: formatBattleResponse(readyBattle),
       coinReward: winnerRole === "attacker" ? coinReward : 0,
       currency: attackerCurrency || { balance: 0, totalEarned: 0 },
     });

--- a/pet-creation/app.js
+++ b/pet-creation/app.js
@@ -3161,7 +3161,14 @@ async function pollArenaBattleRecord(battleId, {
   interval = ARENA_BATTLE_POLL_INTERVAL,
 } = {}) {
   for (let attempt = 0; attempt < attempts; attempt += 1) {
-    const payload = await fetchArenaBattleRecord(battleId);
+    let payload = null;
+    try {
+      payload = await fetchArenaBattleRecord(battleId);
+    } catch (error) {
+      if (error?.code !== "BATTLE_NOT_FOUND") {
+        throw error;
+      }
+    }
 
     if (payload?.status === "ready") {
       return payload;
@@ -6029,8 +6036,10 @@ async function startFightFlow(characterId) {
       recoveryMessage: "",
     });
 
+    const inlineBattle =
+      createBattlePayload?.battle?.status === "ready" ? createBattlePayload.battle : null;
     const [readyBattle, preparedReveal] = await Promise.all([
-      pollArenaBattleRecord(createdBattleId),
+      inlineBattle ? Promise.resolve(inlineBattle) : pollArenaBattleRecord(createdBattleId),
       preparedPoolPromise.then((preparedPool) =>
         prepareArenaRevealCandidates(revealBundle, preparedPool)
       ),

--- a/tests/unit/battle-reveal-api.test.js
+++ b/tests/unit/battle-reveal-api.test.js
@@ -62,7 +62,9 @@ test("POST /api/battles returns an authoritative reveal bundle with the selected
 
     assert.equal(response.statusCode, 200);
     assert.match(response.body.battleId, /^battle_/);
-    assert.equal(response.body.status, "generating");
+    assert.equal(response.body.status, "ready");
+    assert.equal(response.body.battle?.status, "ready");
+    assert.equal(response.body.battle?.id, response.body.battleId);
     assert.equal(response.body.reveal.selectedOpponent.id, "pet_rival");
     assert.ok(
       response.body.reveal.carouselCandidates.some((entry) => entry.id === "pet_rival")


### PR DESCRIPTION
## Summary

Fixes the production bug where pressing **Fight** on My Pets resulted in a "Battle replay is not available" toast, even though XP and Points were credited and the battle eventually appeared in Arena history a few minutes later.

### Root cause
After saving a battle to `@vercel/blob`, the public CDN took time to propagate the new index snapshot. The client polled `GET /api/battles/{id}` immediately after `POST /api/battles` and the first 404 from a stale snapshot threw straight out of `pollArenaBattleRecord` — no retry on `BATTLE_NOT_FOUND`. Wallet-profile blob (different key) was already fresh, which is why rewards were visible while the replay was not.

### Fix
- **Server**: `POST /api/battles` now returns the fully-built `battle` record (status `ready`) in the response payload. The simulation finishes before we reply anyway, so we may as well skip the round-trip.
- **Client (new battle)**: read the inline record from the POST response — no CDN GET on the hot path.
- **Client (replay polling)**: `pollArenaBattleRecord` now treats `BATTLE_NOT_FOUND` as "not yet, keep waiting" instead of failing the cycle. Defensive net for replays of generating battles.
- **Test**: contract assertion updated to the new shape (`status: ready` + inline `battle`).

### Impact
- Fight from My Pets resolves immediately into the battle screen, regardless of CDN warmup.
- Replays of mid-flight battles no longer error out on transient 404s.
- Battle history continues to read through the same CDN-cached blob; it'll catch up as before, but it is no longer the critical path for showing the user their just-finished fight.

Reported against battle `780a8d07-53bf-4308-bfe4-81ee5a21b2ca` — the record was persisted correctly, the issue was the read path.

## Test plan

- [x] `npm test` — 105 / 105 pass.
- [ ] Dev-server: trigger a battle, confirm the result screen opens without "Battle replay is not available" and rewards/replay are consistent.
- [ ] Dev-server: open an old battle from Arena history, replay still loads.
- [ ] Production: run a fresh battle right after merge, confirm no regression and result screen comes up immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)