### PR TITLE
Stop wiping freshly fetched draft when /me also returns a character

### DIFF
--- a/pet-creation/app.js
+++ b/pet-creation/app.js
@@ -1773,7 +1773,7 @@ function syncStateWithPayload(payload = {}) {
 
   if ("character" in payload) {
     state.character = normalizeCharacterRecord(payload.character);
-    if (payload.character) {
+    if (payload.character && !("draft" in payload)) {
       state.draft = null;
     }
   } else if (!state.draft) {


### PR DESCRIPTION
## Summary
- `syncStateWithPayload` was nulling `state.draft` whenever `payload.character` was non-null, but `/api/character/me` always returns both `draft` and `character` (latest completed pet). Any wallet with one finalized pet therefore lost its draft on every `/me` call.
- Knock-on effects seen in prod logs: `select-power` requests going out with `draftId: ""` → server falling back to "last draft on wallet" or returning 400 `Character draft not found. Start again.`; the powers step rendering the previously-saved pet's image; refresh during creation snapping back to the type step.
- Fix: only wipe `state.draft` when the response carried `character` *without* a `draft` field (the `create`/`upgrade` responses). For `/me`, the freshly hydrated draft is preserved.

## Test plan
- [x] `npm test` (123 passing)
- [ ] Manual: create a pet on a wallet that already has one — verify powers step shows the new image and select-power succeeds without `Character draft not found`
- [ ] Manual: refresh during creation — verify the flow resumes on powers/attrs instead of restarting