### PR TITLE
Send selectedPowerId on /character/create to dodge blob read race

### DIFF
--- a/pet-creation/app.js
+++ b/pet-creation/app.js
@@ -7727,6 +7727,7 @@ async function completeCharacterCreation() {
   try {
     const data = await apiRequest("/api/character/create", {
       draftId: state.draft?.id || "",
+      selectedPowerId: state.selectedPowerId || state.draft?.selectedPowerId || "",
       stats: state.attrs,
     });
 


### PR DESCRIPTION
## Summary
- After /select-power succeeded the client called /character/create with only `draftId` + `stats`. The server then derived the chosen power from `current.draft.selectedPowerId`, which is re-read from Vercel Blob.
- When that read raced the just-finished select-power write, the field came back empty, `current.draft.powers.find(...)` returned undefined, and the user saw \"Selected superpower is invalid.\" (reproduced in prod logs for char_06fc8ca2 at 12:04:57Z, ~8s after a successful select-power).
- The create endpoint already accepts `selectedPowerId` in the body and prefers it over the stored draft (server-routes/character/create.js:60). The fix just passes the client's known selection through, so finalization no longer depends on blob propagation.

## Test plan
- [x] \`npm test\` (123 passing)
- [ ] Manual: full create flow on a wallet that already has a pet — distribute attributes and confirm finalization no longer fails with \"Selected superpower is invalid.\"