### PR TITLE
Cap wallet profile read cache at 100ms to avoid cross-request stale reads

### DIFF
--- a/api/_lib/store.js
+++ b/api/_lib/store.js
@@ -44,6 +44,7 @@ const EMPTY_WALLET_PROFILE = {
 let writeQueue = Promise.resolve();
 const walletWriteQueues = new Map();
 const walletProfileReadCache = new Map();
+const WALLET_PROFILE_READ_CACHE_TTL_MS = 100;
 let dbReadCache = null;
 
 function clearWalletProfileCache(wallet) {
@@ -373,9 +374,12 @@ async function getWalletProfile(wallet) {
   }
 
   const cached = walletProfileReadCache.get(wallet);
-  if (cached) {
-    const profile = await cached;
+  if (cached && cached.expiresAt > Date.now()) {
+    const profile = await cached.promise;
     return cloneWalletProfile(profile);
+  }
+  if (cached) {
+    walletProfileReadCache.delete(wallet);
   }
 
   const pending = (async () => {
@@ -388,7 +392,10 @@ async function getWalletProfile(wallet) {
     return normalizeWalletProfile(legacySnapshot?.db?.records?.[wallet]);
   })();
 
-  walletProfileReadCache.set(wallet, pending);
+  walletProfileReadCache.set(wallet, {
+    promise: pending,
+    expiresAt: Date.now() + WALLET_PROFILE_READ_CACHE_TTL_MS,
+  });
 
   try {
     const profile = await pending;


### PR DESCRIPTION
## Summary
- Reproduced in prod (char_d931de2e, 12:09:20Z): \`POST /character/start\` succeeded, then \`POST /character/select-power\` 28s later with the correct \`draftId\` returned 400 \"Character draft not found. Start again.\"
- Root cause: \`walletProfileReadCache\` is a process-local Map. If instance A previously cached a profile via \`GET /me\` (no draft) and instance B handled the subsequent \`/start\`, B writes the new draft to blob and only invalidates B's cache. The next \`/select-power\` routed back to instance A still hits A's stale cache → server thinks \`current.draft === null\` even though the blob is fresh.
- Fix: cap the in-memory cache with a 100ms TTL. Within a single request all \`getWalletProfile\` calls happen in microseconds (dedupe still saves blob ops), but the cache no longer leaks stale state across requests on the same warm instance.

## Test plan
- [x] \`npm test\` (123 passing — existing dedupe tests stay green because they complete well under 100ms)
- [ ] Manual: full create flow on a wallet with one existing pet, several seconds between \`/start\` and \`/select-power\` — confirm no \"Character draft not found\" recurrence