### PR TITLE
Preload draft image before showing powers step to dodge stale render

### DIFF
--- a/pet-creation/app.js
+++ b/pet-creation/app.js
@@ -1719,6 +1719,23 @@ function setCharacterImages(src, creatureType) {
   });
 }
 
+function preloadCharacterImage(src, timeoutMs = 4000) {
+  if (!src || src === DEFAULT_CHARACTER_IMAGE) return Promise.resolve();
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = () => {
+      if (settled) return;
+      settled = true;
+      resolve();
+    };
+    const img = new Image();
+    img.onload = finish;
+    img.onerror = finish;
+    img.src = src;
+    window.setTimeout(finish, timeoutMs);
+  });
+}
+
 function syncTypeSelectionWithRecord(record) {
   const creatureType = record?.creatureType || "";
   if (!creatureType) {
@@ -7659,6 +7676,7 @@ async function startCharacterCreation() {
     ]);
 
     syncStateWithPayload(data);
+    await preloadCharacterImage(state.draft?.imageUrl);
     moveTo("powers");
   } catch (error) {
     moveTo("type");


### PR DESCRIPTION
## Summary
- After /character/start the powers screen briefly showed the **previous** pet's image while the new draft image was still being fetched from Vercel Blob.
- Cause: \`setCharacterImages\` swaps \`<img>.src\`, but until the new src finishes loading the browser keeps rendering whatever was last decoded for that element. \`restoreWalletSession()\` runs without \`await\` on init (pet-creation/app.js:8162), so a fast tap on Continue can land between the eager \`setCharacterImages(DEFAULT)\` and the post-/start swap. In that window \`restoreCharacterState\` writes \`lastChar.imageUrl\` into the .pet-result-image elements, the browser fully decodes it (it's already in cache from success/cabinet), and that frame is what stays on screen until the new blob URL finishes loading.
- Fix: add \`preloadCharacterImage()\` and \`await\` it after \`syncStateWithPayload(data)\` and before \`moveTo(\"powers\")\`. The new image is fully decoded into cache before the screen flips, so the swap is atomic. 4s timeout protects against stuck CDN.

## Test plan
- [x] \`npm test\` (123 passing)
- [ ] Manual: create pet on wallet that already has a finalized pet; confirm powers step shows the new pet immediately, no flash of the old one