### PR TITLE
Bypass Vercel Blob CDN cache when reading wallet profiles

### DIFF
--- a/api/_lib/store.js
+++ b/api/_lib/store.js
@@ -153,6 +153,7 @@ async function readBlobText(stream) {
 async function loadLegacyBlobDbSnapshot() {
   const blobResult = await get(DB_BLOB_PATH, {
     access: "public",
+    useCache: false,
   }).catch((error) => {
     if (error?.name === "BlobNotFoundError") {
       return null;
@@ -259,6 +260,7 @@ async function loadWalletProfileFromBlobPath(pathname) {
 
   const blobResult = await get(pathname, {
     access: "public",
+    useCache: false,
   }).catch((error) => {
     if (error?.name === "BlobNotFoundError") {
       return null;


### PR DESCRIPTION
## Summary
- Real root cause of recurring \"Character draft not found. Start again.\" — confirmed in prod logs for wallet Csu1HXcVb… at 12:45:06Z (~26s after a successful /start that wrote draft=char_baab547d).
- @vercel/blob's \`get(pathname, { access: \"public\" })\` routes through the public CDN by default. Source [v2.3.1](https://github.com/vercel/storage/blob/main/packages/blob/src/index.ts): only when \`useCache:false\` is set does it append \`?cache=0\` to bypass. Combined with \`addRandomSuffix:false + allowOverwrite:true\` (same URL reused per write), CDN edges can serve a stale snapshot for seconds even though the origin blob is fresh. \`cacheControlMaxAge:0\` is respected by origin but not strictly enforced across edges.
- The earlier 100ms in-memory cache TTL (PR #6) only fixed per-instance Map staleness. The CDN read on cold instances still served older writes — that's why the bug kept reappearing on different wallets and different timing windows.
- Fix: pass \`useCache:false\` to the two \`get()\` call-sites that read wallet profiles (deterministic and legacy DB paths). Image reads keep CDN caching since they're immutable per characterId.

## Test plan
- [x] \`npm test\` (123 passing — fake blob in tests ignores options, so no impact)
- [ ] Manual: create two pets in a row on a fresh wallet; confirm select-power on the second pet works without \"Character draft not found\"