### PR TITLE
Retry select-power and create on transient blob CDN staleness

### DIFF
--- a/server-routes/character/create.js
+++ b/server-routes/character/create.js
@@ -6,7 +6,14 @@ const {
   validateSkillAllocation,
 } = require("../../api/_lib/character");
 const { isCharacterProxyEnabled, proxyCharacterJson } = require("../../api/_lib/character-proxy");
-const { updateWalletProfile } = require("../../api/_lib/store");
+const { clearWalletProfileCache, updateWalletProfile } = require("../../api/_lib/store");
+
+const DRAFT_NOT_FOUND_MESSAGE = "Character draft not found. Start again.";
+const DRAFT_RETRY_DELAYS_MS = [200, 400, 800];
+
+function wait(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
 
 module.exports = async (req, res) => {
   if (handleCors(req, res)) return;
@@ -41,48 +48,75 @@ module.exports = async (req, res) => {
       })
     );
 
-    const profile = await updateWalletProfile(session.wallet, async (current) => {
-      if (!current.draft) {
-        throw new Error("Character draft not found. Start again.");
+    const runUpdate = () =>
+      updateWalletProfile(session.wallet, async (current) => {
+        if (!current.draft) {
+          throw new Error(DRAFT_NOT_FOUND_MESSAGE);
+        }
+
+        if (draftId && String(current.draft.id || "") !== draftId) {
+          throw new Error("Character draft changed. Start again.");
+        }
+
+        const attributePointBudget = getAttributePointBudget(current.draft);
+        if (!validateSkillAllocation(stats, attributePointBudget)) {
+          throw new Error(
+            `Invalid attribute allocation. Exactly ${attributePointBudget} points are required.`
+          );
+        }
+
+        const nextSelectedPowerId = selectedPowerId || current.draft.selectedPowerId;
+        const selectedPower = current.draft.powers.find((power) => power.id === nextSelectedPowerId);
+        if (!selectedPower) {
+          throw new Error("Selected superpower is invalid.");
+        }
+
+        const now = new Date().toISOString();
+        const completedCharacter = {
+          ...current.draft,
+          status: "completed",
+          selectedPowerId: nextSelectedPowerId,
+          attributes: normalizeAttributes(stats),
+          level: 1,
+          experience: 0,
+          softCurrency: 0,
+          attributePointsAvailable: 0,
+          completedAt: now,
+          updatedAt: now,
+        };
+
+        return {
+          ...current,
+          draft: null,
+          characters: [...current.characters, completedCharacter],
+        };
+      });
+
+    let profile;
+    let lastError;
+    for (let attempt = 0; attempt <= DRAFT_RETRY_DELAYS_MS.length; attempt++) {
+      try {
+        profile = await runUpdate();
+        if (attempt > 0) {
+          console.log(
+            "[character:create:retry-recovered]",
+            JSON.stringify({ wallet: session.wallet, attempt })
+          );
+        }
+        break;
+      } catch (error) {
+        lastError = error;
+        const retryable = draftId && error.message === DRAFT_NOT_FOUND_MESSAGE;
+        if (!retryable || attempt === DRAFT_RETRY_DELAYS_MS.length) {
+          throw error;
+        }
+        clearWalletProfileCache(session.wallet);
+        await wait(DRAFT_RETRY_DELAYS_MS[attempt]);
       }
-
-      if (draftId && String(current.draft.id || "") !== draftId) {
-        throw new Error("Character draft changed. Start again.");
-      }
-
-      const attributePointBudget = getAttributePointBudget(current.draft);
-      if (!validateSkillAllocation(stats, attributePointBudget)) {
-        throw new Error(
-          `Invalid attribute allocation. Exactly ${attributePointBudget} points are required.`
-        );
-      }
-
-      const nextSelectedPowerId = selectedPowerId || current.draft.selectedPowerId;
-      const selectedPower = current.draft.powers.find((power) => power.id === nextSelectedPowerId);
-      if (!selectedPower) {
-        throw new Error("Selected superpower is invalid.");
-      }
-
-      const now = new Date().toISOString();
-      const completedCharacter = {
-        ...current.draft,
-        status: "completed",
-        selectedPowerId: nextSelectedPowerId,
-        attributes: normalizeAttributes(stats),
-        level: 1,
-        experience: 0,
-        softCurrency: 0,
-        attributePointsAvailable: 0,
-        completedAt: now,
-        updatedAt: now,
-      };
-
-      return {
-        ...current,
-        draft: null,
-        characters: [...current.characters, completedCharacter],
-      };
-    });
+    }
+    if (!profile) {
+      throw lastError;
+    }
 
     const latestCharacter = profile.characters[profile.characters.length - 1] || null;
 

--- a/server-routes/character/select-power.js
+++ b/server-routes/character/select-power.js
@@ -1,7 +1,14 @@
 const { getSessionFromRequest, handleCors, json, parseJsonBody } = require("../../api/_lib/auth");
 const { serializeCharacterRecord } = require("../../api/_lib/character");
 const { isCharacterProxyEnabled, proxyCharacterJson } = require("../../api/_lib/character-proxy");
-const { updateWalletProfile } = require("../../api/_lib/store");
+const { clearWalletProfileCache, updateWalletProfile } = require("../../api/_lib/store");
+
+const DRAFT_NOT_FOUND_MESSAGE = "Character draft not found. Start again.";
+const DRAFT_RETRY_DELAYS_MS = [200, 400, 800];
+
+function wait(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
 
 module.exports = async (req, res) => {
   if (handleCors(req, res)) return;
@@ -39,29 +46,56 @@ module.exports = async (req, res) => {
       return;
     }
 
-    const profile = await updateWalletProfile(session.wallet, async (current) => {
-      if (!current.draft) {
-        throw new Error("Character draft not found. Start again.");
-      }
+    const runUpdate = () =>
+      updateWalletProfile(session.wallet, async (current) => {
+        if (!current.draft) {
+          throw new Error(DRAFT_NOT_FOUND_MESSAGE);
+        }
 
-      if (draftId && String(current.draft.id || "") !== draftId) {
-        throw new Error("Character draft changed. Start again.");
-      }
+        if (draftId && String(current.draft.id || "") !== draftId) {
+          throw new Error("Character draft changed. Start again.");
+        }
 
-      const selectedPower = current.draft.powers.find((power) => power.id === selectedPowerId);
-      if (!selectedPower) {
-        throw new Error("Selected superpower is invalid.");
-      }
+        const selectedPower = current.draft.powers.find((power) => power.id === selectedPowerId);
+        if (!selectedPower) {
+          throw new Error("Selected superpower is invalid.");
+        }
 
-      return {
-        ...current,
-        draft: {
-          ...current.draft,
-          selectedPowerId,
-          updatedAt: new Date().toISOString(),
-        },
-      };
-    });
+        return {
+          ...current,
+          draft: {
+            ...current.draft,
+            selectedPowerId,
+            updatedAt: new Date().toISOString(),
+          },
+        };
+      });
+
+    let profile;
+    let lastError;
+    for (let attempt = 0; attempt <= DRAFT_RETRY_DELAYS_MS.length; attempt++) {
+      try {
+        profile = await runUpdate();
+        if (attempt > 0) {
+          console.log(
+            "[character:select-power:retry-recovered]",
+            JSON.stringify({ wallet: session.wallet, attempt })
+          );
+        }
+        break;
+      } catch (error) {
+        lastError = error;
+        const retryable = draftId && error.message === DRAFT_NOT_FOUND_MESSAGE;
+        if (!retryable || attempt === DRAFT_RETRY_DELAYS_MS.length) {
+          throw error;
+        }
+        clearWalletProfileCache(session.wallet);
+        await wait(DRAFT_RETRY_DELAYS_MS[attempt]);
+      }
+    }
+    if (!profile) {
+      throw lastError;
+    }
 
     console.log(
       "[character:select-power:success]",


### PR DESCRIPTION
## Context
PR #8 attempted to bypass Vercel Blob's CDN cache via \`useCache:false\`. The backend returned 400 Bad Request to the resulting \`?cache=0\` query, took /api/character/me down, and was reverted in 584a0ce.

## Problem
With \`addRandomSuffix:false + allowOverwrite:true\` the blob URL is stable across writes, so a CDN edge can serve a pre-write snapshot for a few seconds. That's what was making \"Character draft not found. Start again.\" recurring on the second-pet flow:
- /start writes draft=… to blob
- /select-power lands on a cold instance, gets the pre-/start snapshot from CDN, sees no draft → 400.

## Fix
Until profiles can move off public blob entirely, retry the updater on transient draft-not-found:
- Only retry when the client passed a real \`draftId\` (so we don't paper over genuine \"no draft\" cases)
- On each retry, invalidate the in-memory cache for that wallet and wait (200ms → 400ms → 800ms)
- After ~1.4s, surface the original error

Same wrapper added to \`/create\` since it hits the same race.

## Test plan
- [x] \`npm test\` (123 passing)
- [ ] Manual: create two pets in a row on a fresh wallet; second pet's select-power should succeed without \"Character draft not found\"