### PR TITLE
Reject stale /me payloads that drop characters we already know exist

### DIFF
--- a/pet-creation/app.js
+++ b/pet-creation/app.js
@@ -1774,26 +1774,37 @@ function syncStateWithPayload(payload = {}) {
     }
   }
 
+  let isStaleProfilePayload = false;
   if (Array.isArray(payload.characters)) {
-    state.characters = payload.characters.map(normalizeCharacterRecord);
-    state.hasHydratedCharacters = true;
-    if (state.characters.length) {
-      void warmArenaOpponentPool().catch(() => {});
-    } else {
-      clearArenaOpponentCache();
+    const incomingIds = new Set(
+      payload.characters.map((record) => record?.id).filter(Boolean)
+    );
+    const knownDropped = state.characters.filter(
+      (record) => record?.id && !incomingIds.has(record.id)
+    );
+    isStaleProfilePayload =
+      state.hasHydratedCharacters && state.characters.length > 0 && knownDropped.length > 0;
+    if (!isStaleProfilePayload) {
+      state.characters = payload.characters.map(normalizeCharacterRecord);
+      state.hasHydratedCharacters = true;
+      if (state.characters.length) {
+        void warmArenaOpponentPool().catch(() => {});
+      } else {
+        clearArenaOpponentCache();
+      }
     }
   }
 
-  if ("draft" in payload) {
+  if ("draft" in payload && !isStaleProfilePayload) {
     state.draft = normalizeCharacterRecord(payload.draft);
   }
 
-  if ("character" in payload) {
+  if ("character" in payload && !isStaleProfilePayload) {
     state.character = normalizeCharacterRecord(payload.character);
     if (payload.character && !("draft" in payload)) {
       state.draft = null;
     }
-  } else if (!state.draft) {
+  } else if (!("character" in payload) && !state.draft) {
     state.character = state.characters[state.characters.length - 1] || null;
   }
 


### PR DESCRIPTION
## Summary
Symptom: after creating a pet, it briefly vanishes from \"My pets\" and reappears ~minute later.

Root cause: \`/character/create\` returns \`{character, characters:[…with new pet]}\` and the client renders correctly. The next background \`GET /me\` poll fires within seconds and Vercel Blob's CDN edge can still serve a pre-write snapshot — \`characters\` comes back without the new pet. \`syncStateWithPayload\` was blindly overwriting \`state.characters\` with the stale list, so the new pet disappeared from the UI until the CDN finally propagated.

Fix: detect stale payloads in \`syncStateWithPayload\` — if the incoming \`characters\` array drops a pet whose id we already hold locally (after at least one hydration), treat the whole profile payload as stale and skip the \`characters\` / \`draft\` / \`character\` updates. Other fields (battleState, currency) keep updating since they aren't part of this race.

Tradeoff: legitimate deletions made elsewhere won't reflect until the next non-stale payload (or a page reload). Acceptable given today's admin tooling.

## Test plan
- [x] \`npm test\` (123 passing)
- [ ] Manual: create a pet, confirm it stays in the list immediately and doesn't vanish during background polling