### PR TITLE
SPA-navigate Go to My Pets so the just-created pet stays visible

### DIFF
--- a/pet-creation/app.js
+++ b/pet-creation/app.js
@@ -7875,7 +7875,11 @@ function init() {
   }
 
   document.getElementById("openCabinetBtn").addEventListener("click", () => {
-    window.location.href = new URL(DASHBOARD_ROUTE, window.location.origin).toString();
+    const dashboardUrl = new URL(DASHBOARD_ROUTE, window.location.origin).toString();
+    if (window.history && typeof window.history.pushState === "function") {
+      window.history.pushState({}, "", dashboardUrl);
+    }
+    moveTo("cabinet");
   });
 
   if (shareSuccessBtn) {


### PR DESCRIPTION
## Summary
After /character/create the new pet appeared in state.characters, but the success-screen \"Go to My Pets\" button used \`window.location.href = /dashboard/\`. That full page reload dropped the in-memory state, the fresh load called GET /me, and Vercel Blob's CDN briefly served the pre-write snapshot — so the cabinet rendered the list without the just-created pet. A user-initiated refresh ~30s later picked up the pet once the CDN propagated.

Fix: switch to \`history.pushState\` + \`moveTo(\"cabinet\")\`. Same document, state preserved, URL still becomes /dashboard/ for sharing/bookmarking. The stale-payload guard from PR #10 keeps the in-flight poll from clobbering state.characters once we land on cabinet.

If the user hard-refreshes, normal hydration applies — by then the CDN has usually caught up.

## Test plan
- [x] \`npm test\` (123 passing)
- [ ] Manual: create a pet, click \"Go to My Pets\" — confirm it appears in the cabinet immediately, no flicker, no need to refresh