### PR TITLE
Apply battle XP locally so the loser's +25 isn't masked by stale /me

### DIFF
--- a/pet-creation/app.js
+++ b/pet-creation/app.js
@@ -1736,6 +1736,34 @@ function preloadCharacterImage(src, timeoutMs = 4000) {
   });
 }
 
+function applyArenaRewardsToInitiator(rewards, initiatorId) {
+  if (!rewards || !initiatorId) return;
+  const id = String(initiatorId);
+  const newExperience = Math.max(0, Math.floor(Number(rewards.newExperience) || 0));
+  const newLevel = Math.max(1, Math.floor(Number(rewards.newLevel) || 1));
+  const newAttributePointsAvailable = Math.max(
+    0,
+    Math.floor(Number(rewards.newAttributePointsAvailable) || 0)
+  );
+  const updatedAt = new Date().toISOString();
+
+  const merge = (record) => {
+    if (!record || String(record.id || "") !== id) return record;
+    return {
+      ...record,
+      experience: newExperience,
+      level: newLevel,
+      attributePointsAvailable: newAttributePointsAvailable,
+      updatedAt,
+    };
+  };
+
+  state.characters = state.characters.map(merge);
+  if (state.character) {
+    state.character = merge(state.character);
+  }
+}
+
 function syncTypeSelectionWithRecord(record) {
   const creatureType = record?.creatureType || "";
   if (!creatureType) {
@@ -6097,7 +6125,11 @@ async function startFightFlow(characterId) {
       prepareArenaRecordImage(resolvedOpponent),
     ]);
 
+    applyArenaRewardsToInitiator(readyBattle?.result?.attackerRewards, initiator.id);
+
     await refreshArenaProfileState().catch(() => null);
+
+    applyArenaRewardsToInitiator(readyBattle?.result?.attackerRewards, initiator.id);
 
     // refreshArenaProfileState reads /api/character/me, which goes through the
     // same blob CDN that may briefly serve a stale snapshot (no Points credited


### PR DESCRIPTION
## Summary
Repro: battle_a10a3ac1-4cf2-40c9-b10f-dec231ffa2a6 — initiator lost, server credited +25 XP, but the pet's experience never moved in the cabinet UI.

Root cause is server-side correct: \`applyAttackerBattleMutation\` writes the new progression to the wallet profile blob unconditionally (loss → +25 attacker XP per \`getBattleXpReward\`). The client receives \`result.attackerRewards\` in the POST /api/battles response with full \`{xpGained, newLevel, newExperience, newAttributePointsAvailable}\`. But it only used those to render the \"+25 Exp.\" label on the result screen — never wrote them into \`state.characters\` / \`state.character\`. The cabinet therefore showed whatever GET /me returned next, and Vercel Blob CDN often serves a pre-write snapshot for several seconds.

Fix: \`applyArenaRewardsToInitiator()\` writes the rewards into \`state.characters[i]\` and \`state.character\` after the battle response. Called twice around \`refreshArenaProfileState()\` (mirroring the existing \`pendingCurrency\` pattern) so a stale /me poll can't strip the values back. Local \`updatedAt\` is bumped to now — once /me starts returning fresh data its newer \`updatedAt\` wins on the next sync.

## Test plan
- [x] \`npm test\` (123 passing)
- [ ] Manual: lose a battle as attacker; confirm +25 XP appears immediately on the pet card and stays there