### PR TITLE
Keep Framer footer container in place and lay it out as one row

### DIFF
--- a/index.html
+++ b/index.html
@@ -543,62 +543,57 @@
         outline: none;
       }
 
-      .framer-105p8lt {
-        display: none !important;
+      .framer-105p8lt[data-border="true"] {
+        display: flex !important;
+        flex-direction: row !important;
+        align-items: center !important;
+        justify-content: space-between !important;
+        gap: 24px !important;
+        padding: 0 clamp(20px, 6vw, 64px) !important;
+        height: 96px !important;
       }
 
-      .petix-landing-footer {
-        position: relative;
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        gap: 24px;
-        padding: 24px clamp(20px, 6vw, 64px);
-        border-top: 1px solid #eaecf0;
-        background: #ffffff;
-        font-family: "Figtree", Arial, sans-serif;
+      .framer-105p8lt .framer-1mhyzhh {
+        position: static !important;
+        transform: none !important;
+        left: auto !important;
+        top: auto !important;
       }
 
-      .petix-landing-footer-logo {
-        display: inline-flex;
-        align-items: center;
+      .framer-105p8lt .framer-12qulzg {
+        position: static !important;
+        transform: none !important;
+        left: auto !important;
+        top: auto !important;
+        width: auto !important;
+        display: flex !important;
+        flex-direction: row !important;
+        align-items: center !important;
+        gap: 28px !important;
+      }
+
+      .framer-105p8lt .framer-1krhc12 {
+        flex: 0 0 auto !important;
+        width: auto !important;
+        display: flex !important;
+        flex-direction: row !important;
+        gap: 28px !important;
+      }
+
+      .framer-105p8lt .framer-15k2rxr,
+      .framer-105p8lt .framer-1uxfe5q {
+        gap: 0 !important;
+      }
+
+      .framer-105p8lt .framer-n1t8vm,
+      .framer-105p8lt .framer-16rrykd {
+        width: auto !important;
+      }
+
+      .framer-105p8lt .framer-n1t8vm a,
+      .framer-105p8lt .framer-16rrykd a {
+        color: inherit;
         text-decoration: none;
-      }
-
-      .petix-landing-footer-logo img {
-        display: block;
-        height: 32px;
-        width: auto;
-      }
-
-      .petix-landing-footer-links {
-        display: flex;
-        align-items: center;
-        gap: 28px;
-      }
-
-      .petix-landing-footer-links a {
-        color: #667085;
-        font-size: 15px;
-        font-weight: 500;
-        text-decoration: none;
-      }
-
-      .petix-landing-footer-links a:hover,
-      .petix-landing-footer-links a:focus-visible {
-        color: #101828;
-        outline: none;
-      }
-
-      @media (max-width: 480px) {
-        .petix-landing-footer {
-          padding: 20px;
-          gap: 16px;
-        }
-
-        .petix-landing-footer-links {
-          gap: 20px;
-        }
       }
     </style>
     <!-- End of headEnd -->
@@ -1188,31 +1183,23 @@
 	      node.replaceWith(link);
 	    };
 
-	    const replaceLandingFooter = () => {
-	      document.querySelectorAll(".framer-105p8lt").forEach((node) => node.remove());
-
-	      if (document.querySelector(".petix-landing-footer")) {
-	        return;
-	      }
-
-	      const footer = document.createElement("footer");
-	      footer.className = "petix-landing-footer";
-	      footer.innerHTML = `
-	        <a class="petix-landing-footer-logo" href="/" aria-label="Petix">
-	          <img src="/assets/petix-logo.svg" alt="Petix" width="100" height="32" />
-	        </a>
-	        <nav class="petix-landing-footer-links" aria-label="Petix social links">
-	          <a href="https://github.com/kdmi/Petix" target="_blank" rel="noopener noreferrer">GitHub</a>
-	          <a href="https://x.com/petixfun" target="_blank" rel="noopener noreferrer">@petixfun</a>
-	        </nav>
-	      `;
-
-	      const host = document.querySelector(".framer-DwVgb") || document.body;
-	      host.appendChild(footer);
+	    const pruneLandingFooterClutter = () => {
+	      const trimSelectors = [
+	        ".framer-jb9pr2", // "Company" column header
+	        ".framer-1ydng6c", // Docs link
+	        ".framer-1koapps", // Legal column (header + Privacy + Terms)
+	        ".framer-1l89j6p", // "Social" column header
+	        ".framer-19gajdi", // right column (© Petix + Contact us)
+	      ];
+	      trimSelectors.forEach((selector) => {
+	        document.querySelectorAll(selector).forEach((node) => node.remove());
+	      });
 	    };
 
 	    const updateLandingFooterLinks = () => {
-	      replaceLandingFooter();
+	      pruneLandingFooterClutter();
+	      linkFooterItem(".framer-n1t8vm", "https://github.com/kdmi/Petix", "GitHub");
+	      linkFooterItem(".framer-16rrykd", "https://x.com/petixfun", "@petixfun");
 	    };
 
 	    if (document.readyState === "loading") {


### PR DESCRIPTION
## Summary
PR #13 removed the Framer footer container (.framer-105p8lt) and injected a custom <footer> into .framer-DwVgb. But that container's children are all \`position:absolute\`, so its block-flow height collapses to 0 — the new footer rendered at the top of the page, hidden behind the absolutely positioned hero/content. Result: \"the footer disappeared\".

This PR keeps Framer's footer container exactly where it sits (its own \`position:absolute; top:3786px\`) and:
- removes only the unwanted children via JS: Company/Social column headers, Docs, the Legal column, and the entire right column (© Petix + Contact us)
- overrides the container's layout via CSS to a single flex row, neutralising Framer's absolute positioning on the two main children

Result: logo on the left, GitHub + @petixfun on the right, one horizontal row, no copyright.

## Test plan
- [x] \`npm test\` (123 passing)
- [ ] Manual: scroll to landing footer — confirm it's visible, single-row, logo + two links, no copyright