### PR TITLE
Stop landing footer links from collapsing to one letter per line

### DIFF
--- a/index.html
+++ b/index.html
@@ -583,17 +583,29 @@
       .framer-105p8lt .framer-15k2rxr,
       .framer-105p8lt .framer-1uxfe5q {
         gap: 0 !important;
+        width: auto !important;
+        flex-direction: row !important;
+        align-items: center !important;
       }
 
       .framer-105p8lt .framer-n1t8vm,
       .framer-105p8lt .framer-16rrykd {
         width: auto !important;
+        white-space: nowrap !important;
+        word-break: normal !important;
+        word-wrap: normal !important;
+      }
+
+      .framer-105p8lt .framer-n1t8vm p,
+      .framer-105p8lt .framer-16rrykd p {
+        white-space: nowrap !important;
       }
 
       .framer-105p8lt .framer-n1t8vm a,
       .framer-105p8lt .framer-16rrykd a {
         color: inherit;
         text-decoration: none;
+        white-space: nowrap;
       }
     </style>
     <!-- End of headEnd -->


### PR DESCRIPTION
## Summary
Screenshot showed GitHub and @petixfun rendering as vertical letter-per-line strips. Cause: Framer's CSS gives the link containers \`width: min-content\` + \`word-break: break-word\`, and the inner text containers use \`white-space: pre-wrap\`. Once the layout override forced their parent columns into a row, the link containers had no minimum to expand against and wrapped one letter per line.

Force \`width:auto\`, \`white-space:nowrap\`, \`word-break:normal\` on the link containers, their inner <p>, and the anchor tags. Also expand the parent column wrappers (.framer-15k2rxr / .framer-1uxfe5q) to flex-row so everything stays on a single line next to the logo.

## Test plan
- [ ] Manual: scroll to footer, confirm \"GitHub\" and \"@petixfun\" render normally on one line