### PR TITLE
Drop forced footer height so the page doesn't get a phantom gap below

### DIFF
--- a/index.html
+++ b/index.html
@@ -550,7 +550,6 @@
         justify-content: space-between !important;
         gap: 24px !important;
         padding: 0 clamp(20px, 6vw, 64px) !important;
-        height: 96px !important;
       }
 
       .framer-105p8lt .framer-1mhyzhh {


### PR DESCRIPTION
## Summary
The previous override forced \`.framer-105p8lt\` to \`height: 96px\`, but Framer's parent container's overall page height was computed assuming the original 254px footer. Shrinking only the footer container left a ~158px empty band between the visible footer row and the end of the document.

Drop the explicit height — the container falls back to its Framer-assigned 254px and the flex children stay vertically centred inside it. The footer still reads as one compact row, but the parent layout stops looking truncated.

## Test plan
- [ ] Manual: scroll to footer, confirm no empty gap below the logo/links band, page ends cleanly