### PR TITLE
Client-side retry on Character draft not found, plus stale-draft guard

### DIFF
--- a/pet-creation/app.js
+++ b/pet-creation/app.js
@@ -916,6 +916,30 @@ function wait(ms) {
   });
 }
 
+const DRAFT_NOT_FOUND_MESSAGE = "Character draft not found. Start again.";
+const DRAFT_RETRY_DELAYS_MS = [1000, 2000, 4000, 6000];
+
+async function requestWithDraftRetry(run) {
+  let lastError;
+  for (let attempt = 0; attempt <= DRAFT_RETRY_DELAYS_MS.length; attempt++) {
+    try {
+      return await run();
+    } catch (error) {
+      lastError = error;
+      const message = typeof error?.message === "string" ? error.message : "";
+      const isRetryable =
+        Boolean(state.draft?.id) &&
+        message === DRAFT_NOT_FOUND_MESSAGE &&
+        attempt < DRAFT_RETRY_DELAYS_MS.length;
+      if (!isRetryable) {
+        throw error;
+      }
+      await wait(DRAFT_RETRY_DELAYS_MS[attempt]);
+    }
+  }
+  throw lastError;
+}
+
 function shuffleArray(items = []) {
   const shuffled = [...items];
 
@@ -1824,7 +1848,21 @@ function syncStateWithPayload(payload = {}) {
   }
 
   if ("draft" in payload && !isStaleProfilePayload) {
-    state.draft = normalizeCharacterRecord(payload.draft);
+    const incomingDraft = normalizeCharacterRecord(payload.draft);
+    const localDraftId = state.draft?.id;
+    const incomingDraftId = incomingDraft?.id;
+    const payloadConfirmsCreate =
+      "character" in payload && payload.character && localDraftId &&
+      payload.character.id === localDraftId;
+    // Defend against stale /me reads from Vercel Blob CDN: if we already
+    // hold a draft locally and the incoming payload doesn't know about it,
+    // keep ours. The exception is when the payload is the create response
+    // for our draft — that legitimately clears it.
+    if (localDraftId && incomingDraftId !== localDraftId && !payloadConfirmsCreate) {
+      // ignore — incoming draft is stale (CDN pre-write snapshot)
+    } else {
+      state.draft = incomingDraft;
+    }
   }
 
   if ("character" in payload && !isStaleProfilePayload) {
@@ -7753,10 +7791,12 @@ async function savePowerSelectionAndContinue() {
   }, 8000);
 
   try {
-    const data = await apiRequest("/api/character/select-power", {
-      draftId: state.draft?.id || "",
-      selectedPowerId: state.selectedPowerId,
-    });
+    const data = await requestWithDraftRetry(() =>
+      apiRequest("/api/character/select-power", {
+        draftId: state.draft?.id || "",
+        selectedPowerId: state.selectedPowerId,
+      })
+    );
 
     syncStateWithPayload(data);
     moveTo("attrs");
@@ -7786,11 +7826,13 @@ async function completeCharacterCreation() {
   updateAttrsStep();
 
   try {
-    const data = await apiRequest("/api/character/create", {
-      draftId: state.draft?.id || "",
-      selectedPowerId: state.selectedPowerId || state.draft?.selectedPowerId || "",
-      stats: state.attrs,
-    });
+    const data = await requestWithDraftRetry(() =>
+      apiRequest("/api/character/create", {
+        draftId: state.draft?.id || "",
+        selectedPowerId: state.selectedPowerId || state.draft?.selectedPowerId || "",
+        stats: state.attrs,
+      })
+    );
 
     syncStateWithPayload(data);
     moveTo("success");


### PR DESCRIPTION
## Summary
Repro (logs from 22:32 today):
- 22:32:17  /character/start char_1ca25fba → 200 (blob written)
- 22:32:36  /character/select-power → 400 \"Character draft not found\"

Vercel Blob's public CDN held a pre-write snapshot for 19+ seconds. The earlier server-side retry (PR #9) covers a ~1.4s window before bumping into the function timeout — it can't sit inside a serverless invocation while CDN propagation lags that long.

Plus a secondary symptom: after the 400, a background /me poll returned the stale (pre-write) snapshot, and syncStateWithPayload swapped state.draft for an old draft — that's why the on-screen pet image flipped to a previous Iron Paw the user had seen before.

## Fix
1. **Client-side retry**: new \`requestWithDraftRetry()\` wraps /character/select-power and /character/create. On exact message \"Character draft not found. Start again.\" with \`state.draft.id\` set, it replays at 1s/2s/4s/6s (~13s total). User sees the Continue button stay in saving state instead of an alert.
2. **Stale-draft guard** in \`syncStateWithPayload\`: if we already hold a draft id locally and an incoming payload doesn't know about it (and isn't the matching /create response), keep the local draft. Stops a stale /me from swapping the screen to a previous draft.

## Test plan
- [x] \`npm test\` (123 passing)
- [ ] Manual: create a pet, immediately step through powers/attrs — should not surface \"Character draft not found\" even if /me race lags; previous pet image should not flash on the powers step