### PR TITLE
Hide pet name on the create-flow attrs card (keep it on upgrade)

### DIFF
--- a/pet-creation/app.js
+++ b/pet-creation/app.js
@@ -3930,7 +3930,9 @@ function renderAttrsPetCard(record) {
   applyRarityBadge(attrsPetRarity, resolvedRecord?.rarity);
 
   if (attrsPetName) {
-    attrsPetName.textContent = getRecordDisplayName(resolvedRecord);
+    const showName = isUpgradeStep();
+    attrsPetName.textContent = showName ? getRecordDisplayName(resolvedRecord) : "";
+    attrsPetName.classList.toggle("hidden", !showName);
   }
   if (attrsPetLevel) {
     attrsPetLevel.textContent = `Lvl. ${getRecordLevel(resolvedRecord)}`;


### PR DESCRIPTION
On the Distribute attributes screen during pet creation the right-side card was showing the generated pet name. Hide it for create flow, keep it on upgrade.