### PR TITLE
Withdraw: WITHDRAW_ENABLED toggles admin-only ↔ public

### DIFF
--- a/pet-creation/app.js
+++ b/pet-creation/app.js
@@ -843,6 +843,7 @@ const state = {
   selectedPowerId: "",
   isAuthenticated: false,
   isAdmin: false,
+  withdrawPublic: false, // вывод открыт всем (WITHDRAW_ENABLED=1); иначе попап только у админа
   isStarting: false,
   isSavingPower: false,
   isCreating: false,
@@ -1650,6 +1651,9 @@ async function refreshWithdrawConfig() {
     const res = await apiRequest("/api/withdraw/config", {}, "GET");
     applyWithdrawConfig(res);
     withdrawState.configLoaded = true;
+    state.withdrawPublic = Boolean(res && res.public);
+    // Публичность могла измениться → обновить кликабельность баланса в шапке.
+    updateDashboardPointsUi();
     if (withdrawState.open && withdrawState.view === "form") {
       // Re-clamp the current amount into the (possibly new) min/max bounds.
       setWithdrawAmount(withdrawState.amount);
@@ -1980,7 +1984,7 @@ async function onWithdrawSubmit() {
 }
 
 function openWithdrawModal() {
-  if (!state.isAdmin) return;
+  if (!state.isAdmin && !state.withdrawPublic) return;
   ensureWithdrawModal();
   hideWalletMenu();
   withdrawState.balance = Math.max(0, Math.floor(state.currency?.balance ?? 0));
@@ -2022,11 +2026,14 @@ function showLoggedWalletState({ walletAddress, isAdmin = false }) {
   updateAdminAccessUi();
   updateCreatePetMenuState();
   updateDashboardPointsUi();
+  // Узнать, открыт ли вывод всем (WITHDRAW_ENABLED=1) — чтобы показать кликабельный баланс и не-админам.
+  void refreshWithdrawConfig();
 }
 
 function showWalletAuthState() {
   state.isAuthenticated = false;
   state.isAdmin = false;
+  state.withdrawPublic = false;
   state.walletAddress = "";
   resetUpgradeSession();
   clearArenaOpponentCache();
@@ -4661,8 +4668,8 @@ function updateDashboardPointsUi() {
   if (valueEl) valueEl.textContent = formatCoins(balance);
   dashboardPoints.classList.toggle("hidden", !state.isAuthenticated);
 
-  // Withdraw is admin-only for now — only admins get a clickable balance.
-  const withdrawable = state.isAuthenticated && state.isAdmin;
+  // Кликабельный баланс (вход в вывод): админу всегда, остальным — когда вывод открыт всем.
+  const withdrawable = state.isAuthenticated && (state.isAdmin || state.withdrawPublic);
   dashboardPoints.classList.toggle("is-withdrawable", withdrawable);
   if (withdrawable) {
     dashboardPoints.setAttribute("role", "button");
@@ -8416,7 +8423,7 @@ function renderAdminEconomy() {
           ${ecoNumberRow("Battle level k", "BATTLE_LEVEL_K", cfg.BATTLE_LEVEL_K)}
           ${ecoNumberRow("Min withdraw", "MIN_WITHDRAW", cfg.MIN_WITHDRAW)}
           ${ecoNumberRow("Withdraw fee %", "WITHDRAW_FEE_PCT", cfg.WITHDRAW_FEE_PCT)}
-          ${ecoNumberRow("Withdraw enabled (1=on, 0=off)", "WITHDRAW_ENABLED", cfg.WITHDRAW_ENABLED)}
+          ${ecoNumberRow("Withdraw public (1=all users, 0=admin-only)", "WITHDRAW_ENABLED", cfg.WITHDRAW_ENABLED)}
         </div>
         <label style="display:flex;flex-direction:column;gap:4px;font-size:13px;font-weight:600;margin-top:12px;">
           Slot prices (comma-separated, ${(cfg.MAX_CHARACTER_SLOTS || 10) - 3} values, increasing)
@@ -9213,11 +9220,12 @@ function init() {
   });
 
   if (dashboardPoints) {
+    const canOpenWithdraw = () => state.isAdmin || state.withdrawPublic;
     dashboardPoints.addEventListener("click", () => {
-      if (state.isAdmin) openWithdrawModal();
+      if (canOpenWithdraw()) openWithdrawModal();
     });
     dashboardPoints.addEventListener("keydown", (event) => {
-      if (!state.isAdmin) return;
+      if (!canOpenWithdraw()) return;
       if (event.key === "Enter" || event.key === " ") {
         event.preventDefault();
         openWithdrawModal();

--- a/server-routes/withdraw/config.js
+++ b/server-routes/withdraw/config.js
@@ -1,4 +1,4 @@
-const { getSessionFromRequest, handleCors, json } = require("../../api/_lib/auth");
+const { getSessionFromRequest, handleCors, isAdminWallet, json } = require("../../api/_lib/auth");
 const { getEconomyConfig } = require("../../api/_lib/economy-config");
 const withdraw = require("../../api/_lib/withdraw");
 
@@ -18,9 +18,16 @@ module.exports = async (req, res) => {
   try {
     const cfg = await getEconomyConfig();
     const chain = withdraw.getConfig();
+    const configured = withdraw.isConfigured();
+    const isAdmin = isAdminWallet(session.wallet);
+    // WITHDRAW_ENABLED=1 → открыто всем; =0 → только админ (но он всё равно может тестировать).
+    const publicOpen = Boolean(cfg.WITHDRAW_ENABLED);
+    const available = configured && (publicOpen || isAdmin);
     json(res, 200, {
-      enabled: Boolean(cfg.WITHDRAW_ENABLED) && withdraw.isConfigured(),
-      configured: withdraw.isConfigured(),
+      enabled: available, // может ли ИМЕННО этот пользователь сейчас выводить
+      public: publicOpen, // открыт ли вывод всем (а не только админу)
+      configured,
+      isAdmin,
       min: Math.max(0, Math.floor(Number(cfg.MIN_WITHDRAW) || 0)),
       feePct: Math.max(0, Number(cfg.WITHDRAW_FEE_PCT) || 0),
       tokenSymbol: chain.tokenSymbol,

--- a/server-routes/withdraw/prepare.js
+++ b/server-routes/withdraw/prepare.js
@@ -2,6 +2,7 @@ const crypto = require("crypto");
 const {
   getSessionFromRequest,
   handleCors,
+  isAdminWallet,
   json,
   parseJsonBody,
 } = require("../../api/_lib/auth");
@@ -34,11 +35,13 @@ module.exports = async (req, res) => {
 
   try {
     const cfg = await getEconomyConfig();
-    if (!cfg.WITHDRAW_ENABLED) {
-      throw fail(403, "Withdrawals are currently disabled.", "WITHDRAW_DISABLED");
-    }
     if (!withdraw.isConfigured()) {
       throw fail(503, "Withdrawals are not configured on the server.", "WITHDRAW_NOT_CONFIGURED");
+    }
+    // WITHDRAW_ENABLED=0 → только админ (защита и от прямых вызовов API в обход UI); =1 → все.
+    const publicOpen = Boolean(cfg.WITHDRAW_ENABLED);
+    if (!publicOpen && !isAdminWallet(session.wallet)) {
+      throw fail(403, "Withdrawals are in admin-only mode right now.", "WITHDRAW_ADMIN_ONLY");
     }
 
     const body = await parseJsonBody(req);


### PR DESCRIPTION
Меняет смысл рубильника `WITHDRAW_ENABLED` в одну понятную ручку и закрывает дыру с прямым API.

## Было
`WITHDRAW_ENABLED` = «вкл/выкл для всех», а admin-only держался только на фронте. Бэкенд-эндпоинты админство не проверяли → при флаге=1 любой залогиненный мог вывести через прямой вызов `/api/withdraw/prepare` в обход UI. А при флаге=0 даже админ не мог протестировать.

## Стало
- **`WITHDRAW_ENABLED=0` → только админ.** И в UI (попап у админа), и на бэке: `prepare` пускает только админский кошелёк, остальным `403 WITHDRAW_ADMIN_ONLY`. Админ спокойно тестирует.
- **`WITHDRAW_ENABLED=1` → попап и вывод у всех.**

## Изменения
- `server-routes/withdraw/prepare.js` — admin-гейт когда флаг=0.
- `server-routes/withdraw/config.js` — отдаёт `enabled` (может ли именно этот юзер), `public`, `isAdmin`.
- `pet-creation/app.js` — кликабельный баланс/попап админу всегда, остальным при `public`; `state.withdrawPublic` из конфига после логина; ярлык рубильника → «Withdraw public (1=all users, 0=admin-only)».

## Проверено (локально, dev-сервер)
- Флаг=0: config(admin) `enabled:true,public:false`; config(user) `enabled:false`; `prepare(user)` → **403**.
- Флаг=1: config(user) `enabled:true,public:true`.
- Фронт: флаг=0 не-админ — баланс не кликабелен; флаг=1 — кликабелен, попап открывается.
- 155/155 тестов зелёные.

🤖 Generated with [Claude Code](https://claude.com/claude-code)