### PR TITLE
Fix withdraw 500 on Vercel (rpc-websockets uuid ESM crash)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4756,16 +4756,17 @@
       }
     },
     "node_modules/rpc-websockets/node_modules/uuid": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
-      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist-node/bin/uuid"
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/rpc-websockets/node_modules/ws": {

--- a/package.json
+++ b/package.json
@@ -15,5 +15,10 @@
   },
   "devDependencies": {
     "vercel": "^50.25.2"
+  },
+  "overrides": {
+    "rpc-websockets": {
+      "uuid": "^9.0.1"
+    }
   }
 }


### PR DESCRIPTION
## Проблема
На проде **все `/api/withdraw/*` отдают 500 `FUNCTION_INVOCATION_FAILED`** — функция падает ещё на загрузке модуля (даже без авторизации), поэтому кнопка Withdraw неактивна. `/api/auth/solana/me` и прочее работают.

## Причина
`@solana/web3.js` → `rpc-websockets` → **`uuid@14` (ESM-only, `type: module`)**. CJS-сборка `rpc-websockets` делает `require("uuid")` → `ERR_REQUIRE_ESM` на Node-раннтайме без `require(ESM)` (Vercel < 22.12). Локально на Node 22.16 не воспроизводилось — там `require(ESM)` включён по умолчанию.

Воспроизведение: `node --no-experimental-require-module -e 'require("./api/_lib/withdraw.js")'` → тот самый `ERR_REQUIRE_ESM` на `rpc-websockets/node_modules/uuid`.

## Фикс
`npm overrides` форсит `uuid` **только внутри `rpc-websockets`** на CJS-совместимую `^9.0.1` (API `v4()` идентичен; websocket-подписки в выводе не используются — только HTTP-RPC). Не завязываемся на версию Node Vercel.

## Проверено
- С выключенным `require(ESM)` модуль вывода + диспетчер грузятся без краха.
- `scripts/withdraw-preflight.js` на реальном mainnet-RPC — ОК.
- 155/155 тестов зелёные.

После мёржа Vercel передеплоит → `/api/withdraw/*` перестанут 500-ить, кнопка станет активной (env уже добавлены).

🤖 Generated with [Claude Code](https://claude.com/claude-code)