### PR TITLE
Fix admin Withdraw toggle "stays on 1" + UTF-8 body parsing

### DIFF
--- a/api/_lib/auth.js
+++ b/api/_lib/auth.js
@@ -198,14 +198,21 @@ function json(res, status, body) {
 
 async function parseJsonBody(req) {
   return new Promise((resolve, reject) => {
-    let raw = "";
+    // Собираем сырые байты и декодируем UTF-8 ОДИН раз в конце. Нельзя делать `raw += chunk`:
+    // многобайтовый символ (кириллица/эмодзи) на стыке чанков порвётся и JSON сломается.
+    const chunks = [];
+    let size = 0;
     req.on("data", (chunk) => {
-      raw += chunk;
-      if (raw.length > 1_000_000) {
+      const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      size += buf.length;
+      if (size > 1_000_000) {
         reject(new Error("Request body is too large."));
+        return;
       }
+      chunks.push(buf);
     });
     req.on("end", () => {
+      const raw = Buffer.concat(chunks).toString("utf8");
       if (!raw) {
         resolve({});
         return;

--- a/pet-creation/app.js
+++ b/pet-creation/app.js
@@ -8261,6 +8261,20 @@ function ecoNumberRow(label, key, value) {
     </label>`;
 }
 
+// Выпадающий список для целочисленных переключателей (нельзя оставить пустым → не «теряется» при сохранении).
+function ecoSelectRow(label, key, value, options) {
+  const current = String(value);
+  const opts = options
+    .map((o) => `<option value="${o.value}" ${String(o.value) === current ? "selected" : ""}>${escapeHtml(o.label)}</option>`)
+    .join("");
+  return `
+    <label style="display:flex;flex-direction:column;gap:4px;font-size:13px;font-weight:600;color:#1a1a2e;">
+      ${escapeHtml(label)}
+      <select data-eco-key="${key}"
+        style="padding:8px 10px;border:1px solid #d4d7e0;border-radius:8px;font-size:14px;background:#fff;">${opts}</select>
+    </label>`;
+}
+
 function renderAdminEconomy() {
   if (!adminEconomyPanel) return;
 
@@ -8332,7 +8346,7 @@ function renderAdminEconomy() {
           ${ecoNumberRow("Battle level k", "BATTLE_LEVEL_K", cfg.BATTLE_LEVEL_K)}
           ${ecoNumberRow("Min withdraw", "MIN_WITHDRAW", cfg.MIN_WITHDRAW)}
           ${ecoNumberRow("Withdraw fee %", "WITHDRAW_FEE_PCT", cfg.WITHDRAW_FEE_PCT)}
-          ${ecoNumberRow("Withdraw public (1=all users, 0=admin-only)", "WITHDRAW_ENABLED", cfg.WITHDRAW_ENABLED)}
+          ${ecoSelectRow("Withdraw access", "WITHDRAW_ENABLED", cfg.WITHDRAW_ENABLED, [{ value: 0, label: "0 — admin only" }, { value: 1, label: "1 — all users" }])}
         </div>
         <label style="display:flex;flex-direction:column;gap:4px;font-size:13px;font-weight:600;margin-top:12px;">
           Slot prices (comma-separated, ${(cfg.MAX_CHARACTER_SLOTS || 10) - 3} values, increasing)


### PR DESCRIPTION
Две проблемы, всплывшие при попытке поставить **Withdraw access = 0** в админке (значение «не менялось», помогал только английский reason — но язык был ни при чём).

## 1. Переключатель молча «терялся» при сохранении (главное)
Поле `WITHDRAW_ENABLED` было числовым `input`. Если оставить его **пустым** (а не вписать `0`), `readEcoNumberInput` возвращал `undefined`, и ключ **выпадал из patch** — значение оставалось прежним (1), хотя тост показывал «saved». Отсюда «3 раза сохраняю — остаётся 1».

**Фикс:** рендерим как `<select>` `0 — admin only` / `1 — all users` (`ecoSelectRow`). Пустым оставить нельзя → при сохранении всегда уходит 0 или 1.

## 2. Порча UTF-8 в теле запроса (попутно нашли)
`parseJsonBody` склеивал тело как `raw += chunk` (Buffer → строка покусочно): многобайтовый символ (кириллица/эмодзи) на стыке сетевых чанков рвался. На маленьких телах редко, но на крупных (русские имена/описания питомцев) мог тихо портить текст.

**Фикс:** собираем байты и декодируем UTF-8 один раз — `Buffer.concat(chunks).toString("utf8")`.

## Проверено
- Селект сохраняет 0↔1, значение персистится (`/api/withdraw/config` → `public` 0↔1).
- Репро разреза многобайтового символа: новый парсер декодирует reason верно при любой точке разреза.
- 155/155 тестов.

🤖 Generated with [Claude Code](https://claude.com/claude-code)