### PR TITLE
Monotonic profile snapshots: stale /me can't resurrect burned pets

### DIFF
--- a/api/_lib/store.js
+++ b/api/_lib/store.js
@@ -56,6 +56,7 @@ const EMPTY_WALLET_PROFILE = {
   currency: { balance: 0, totalEarned: 0 },
   paidSlots: 0,
   withdrawals: [],
+  profileUpdatedAt: null,
 };
 
 let writeQueue = Promise.resolve();
@@ -101,7 +102,15 @@ function cloneWalletProfile(profile) {
     withdrawals: Array.isArray(profile?.withdrawals)
       ? profile.withdrawals.map((record) => cloneRecord(record))
       : [],
+    profileUpdatedAt: profile?.profileUpdatedAt ? String(profile.profileUpdatedAt) : null,
   };
+}
+
+// Monotonic write stamp: lets readers (and the client) detect and discard a
+// stale profile snapshot that arrives after a newer write.
+function stampProfileUpdatedAt(profile) {
+  profile.profileUpdatedAt = new Date().toISOString();
+  return profile;
 }
 
 function normalizeWalletProfile(rawValue) {
@@ -515,7 +524,7 @@ async function listAllCharacters() {
 
 async function saveWalletProfile(wallet, profile) {
   if (isBlobDbEnabled()) {
-    const normalized = normalizeWalletProfile(profile);
+    const normalized = stampProfileUpdatedAt(normalizeWalletProfile(profile));
     const key = String(wallet || "").trim();
     const previous = walletWriteQueues.get(key) || Promise.resolve();
     const next = previous.catch(() => null).then(async () => {
@@ -536,7 +545,7 @@ async function saveWalletProfile(wallet, profile) {
   }
 
   return withDbMutation(async (db) => {
-    db.records[wallet] = normalizeWalletProfile(profile);
+    db.records[wallet] = stampProfileUpdatedAt(normalizeWalletProfile(profile));
     return cloneWalletProfile(db.records[wallet]);
   });
 }
@@ -549,8 +558,8 @@ async function updateWalletProfile(wallet, updater) {
       const current = await getWalletProfile(wallet);
       const updated = await updater(cloneWalletProfile(current));
       const normalized = updated
-        ? normalizeWalletProfile(updated)
-        : cloneWalletProfile(EMPTY_WALLET_PROFILE);
+        ? stampProfileUpdatedAt(normalizeWalletProfile(updated))
+        : stampProfileUpdatedAt(cloneWalletProfile(EMPTY_WALLET_PROFILE));
 
       await writeWalletProfileBlob(wallet, normalized);
       walletProfileReadCache.delete(wallet);
@@ -577,7 +586,7 @@ async function updateWalletProfile(wallet, updater) {
       return cloneWalletProfile(EMPTY_WALLET_PROFILE);
     }
 
-    db.records[wallet] = normalizeWalletProfile(next);
+    db.records[wallet] = stampProfileUpdatedAt(normalizeWalletProfile(next));
     return cloneWalletProfile(db.records[wallet]);
   });
 }

--- a/pet-creation/app.js
+++ b/pet-creation/app.js
@@ -918,6 +918,7 @@ const state = {
   burnCost: null,
   openCardMenuId: "",
   burningCharacterId: "",
+  profileUpdatedAt: null,
   farmActionCharacterId: "",
   recentClaims: {},
 };
@@ -2292,6 +2293,17 @@ function syncTypeSelectionWithRecord(record) {
 }
 
 function syncStateWithPayload(payload = {}) {
+  // Monotonic snapshot guard: a /me payload can arrive late (in-flight poll,
+  // focus refresh) or be served stale — never apply a snapshot that is not
+  // strictly newer than what we already have, or a burned pet "resurrects"
+  // and a claimed farm rolls back in the UI without any page refresh.
+  if (payload?.profileUpdatedAt) {
+    if (state.profileUpdatedAt && payload.profileUpdatedAt <= state.profileUpdatedAt) {
+      return;
+    }
+    state.profileUpdatedAt = String(payload.profileUpdatedAt);
+  }
+
   if (payload?.battleState) {
     applyBattleStatePayload(payload.battleState);
     updateEnergyUi();
@@ -7411,6 +7423,15 @@ async function performBurn(characterId, confirmBtn) {
     showToast(`Pet burned — ${formatPoints(result.pricePaid)} Points spent.`);
   } catch (error) {
     closeBurnConfirm();
+    if (error && error.code === "NOT_FOUND") {
+      // The server is the source of truth: the pet is already gone (e.g. a
+      // stale snapshot resurrected it in the UI) — drop the card locally.
+      state.characters = state.characters.filter(
+        (record) => String(record.id) !== String(characterId)
+      );
+      state.openCardMenuId = "";
+      if (isCabinetScreenActive()) renderCabinet();
+    }
     showToast(error.message || "Couldn't burn the pet.");
   } finally {
     burnRequestInFlight = false;

--- a/server-routes/character/me.js
+++ b/server-routes/character/me.js
@@ -45,5 +45,6 @@ module.exports = async (req, res) => {
     maxCharacters: getMaxCharacters(profile, cfg),
     nextSlotPrice: getNextSlotPrice(profile, cfg),
     burnCost: cfg.BURN_COST,
+    profileUpdatedAt: profile.profileUpdatedAt || null,
   });
 };

--- a/tests/unit/profile-updated-at.test.js
+++ b/tests/unit/profile-updated-at.test.js
@@ -1,0 +1,54 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  createCompletedCharacter,
+  createInternalHeaders,
+  createWallet,
+  invokeJsonHandler,
+  withIsolatedBattleHistoryEnv,
+} = require("./helpers/battle-history-test-utils");
+
+// The client uses profileUpdatedAt as a monotonic snapshot guard: a stale /me
+// payload (late poll / cached read) must never override newer local state.
+test("profileUpdatedAt: stamped on every write and exposed by /api/character/me", async () => {
+  await withIsolatedBattleHistoryEnv(async ({ auth, characterActionRoute, store }) => {
+    const wallet = createWallet("9");
+    await store.updateWalletProfile(wallet, async (current) => ({
+      ...current,
+      characters: [createCompletedCharacter({ id: "char_stamp", name: "Stamp" })],
+      currency: { balance: 5000, totalEarned: 5000 },
+    }));
+
+    const first = await invokeJsonHandler(characterActionRoute, {
+      method: "GET",
+      url: "/api/character/me",
+      headers: createInternalHeaders(auth, wallet),
+    });
+    assert.equal(first.statusCode, 200);
+    assert.ok(first.body.profileUpdatedAt, "stamp missing after first write");
+
+    await new Promise((resolve) => setTimeout(resolve, 5));
+
+    const burn = await invokeJsonHandler(characterActionRoute, {
+      method: "POST",
+      url: "/api/character/burn",
+      headers: createInternalHeaders(auth, wallet),
+      body: { petId: "char_stamp" },
+    });
+    assert.equal(burn.statusCode, 200);
+
+    const second = await invokeJsonHandler(characterActionRoute, {
+      method: "GET",
+      url: "/api/character/me",
+      headers: createInternalHeaders(auth, wallet),
+    });
+    assert.equal(second.statusCode, 200);
+    assert.ok(second.body.profileUpdatedAt, "stamp missing after burn");
+    // ISO strings compare lexicographically — the client relies on this.
+    assert.ok(
+      second.body.profileUpdatedAt > first.body.profileUpdatedAt,
+      `stamp did not advance: ${first.body.profileUpdatedAt} → ${second.body.profileUpdatedAt}`
+    );
+  });
+});


### PR DESCRIPTION
Fixes the prod report: a burned pet reappeared ~30s later without a refresh (late /me poll applied a stale snapshot), repeat burn hit 404, refresh showed the truth.

- \`profileUpdatedAt\` stamped on every wallet-profile write, exposed via \`/api/character/me\`
- client ignores any /me payload whose stamp is not strictly newer than the applied one — stale snapshots can't resurrect pets or roll back balances
- burn NOT_FOUND now drops the card locally (server is the source of truth)
- +1 test (stamp monotonicity through burn), 165/165 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)