### PR TITLE
Compare-and-swap wallet-profile writes: no more lost updates

### DIFF
--- a/api/_lib/store.js
+++ b/api/_lib/store.js
@@ -286,7 +286,7 @@ async function listBlobPathnames(prefix) {
   return blobs;
 }
 
-async function loadWalletProfileFromBlobPath(pathname) {
+async function loadWalletProfileBlobWithEtag(pathname) {
   if (!pathname) return null;
 
   const blobResult = await getFreshBlob(pathname, {
@@ -303,7 +303,36 @@ async function loadWalletProfileFromBlobPath(pathname) {
   }
 
   const raw = await readBlobText(blobResult.stream);
-  return normalizeWalletProfile(raw ? JSON.parse(raw) : EMPTY_WALLET_PROFILE);
+  return {
+    profile: normalizeWalletProfile(raw ? JSON.parse(raw) : EMPTY_WALLET_PROFILE),
+    etag: blobResult.blob?.etag || null,
+  };
+}
+
+async function loadWalletProfileFromBlobPath(pathname) {
+  const loaded = await loadWalletProfileBlobWithEtag(pathname);
+  return loaded ? loaded.profile : null;
+}
+
+// Read the deterministic profile blob together with its ETag for a CAS write.
+// `staleEtag` (from a failed ifMatch put) forces re-reads until the storage
+// stops serving that exact stale version.
+async function readWalletProfileForCas(wallet, { staleEtag = null } = {}) {
+  const pathname = buildWalletProfileBlobPath(wallet);
+  let last = null;
+
+  for (let attempt = 0; attempt < 4; attempt += 1) {
+    last = await loadWalletProfileBlobWithEtag(pathname);
+    if (!last) {
+      return { profile: null, etag: null };
+    }
+    if (!staleEtag || !last.etag || last.etag !== staleEtag) {
+      return last;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 120 * (attempt + 1)));
+  }
+
+  return last;
 }
 
 async function loadBlobWalletProfile(wallet) {
@@ -370,14 +399,22 @@ function mergeRecordMaps(...maps) {
   };
 }
 
-async function writeWalletProfileBlob(wallet, profile) {
+async function writeWalletProfileBlob(wallet, profile, { ifMatch = null } = {}) {
   await put(buildWalletProfileBlobPath(wallet), JSON.stringify(normalizeWalletProfile(profile), null, 2), {
     access: "public",
     addRandomSuffix: false,
     allowOverwrite: true,
     contentType: "application/json",
     cacheControlMaxAge: 0,
+    ...(ifMatch ? { ifMatch } : {}),
   });
+}
+
+function isEtagConflictError(error) {
+  return (
+    error?.constructor?.name === "BlobPreconditionFailedError" ||
+    /precondition failed/i.test(String(error?.message || ""))
+  );
 }
 
 async function withDbMutation(mutate) {
@@ -550,21 +587,51 @@ async function saveWalletProfile(wallet, profile) {
   });
 }
 
+const PROFILE_CAS_ATTEMPTS = 5;
+
 async function updateWalletProfile(wallet, updater) {
   if (isBlobDbEnabled()) {
     const key = String(wallet || "").trim();
     const previous = walletWriteQueues.get(key) || Promise.resolve();
     const next = previous.catch(() => null).then(async () => {
-      const current = await getWalletProfile(wallet);
-      const updated = await updater(cloneWalletProfile(current));
-      const normalized = updated
-        ? stampProfileUpdatedAt(normalizeWalletProfile(updated))
-        : stampProfileUpdatedAt(cloneWalletProfile(EMPTY_WALLET_PROFILE));
+      // Compare-and-swap: the in-memory queue only serializes writes within
+      // THIS lambda instance. Concurrent invocations (or a stale read) would
+      // silently clobber each other's writes, so every write carries the
+      // ETag of the profile version it was computed from; on a conflict we
+      // re-read and re-run the updater.
+      let staleEtag = null;
 
-      await writeWalletProfileBlob(wallet, normalized);
-      walletProfileReadCache.delete(wallet);
-      dbReadCache = null;
-      return cloneWalletProfile(normalized);
+      for (let attempt = 0; attempt < PROFILE_CAS_ATTEMPTS; attempt += 1) {
+        const { profile: direct, etag } = await readWalletProfileForCas(wallet, { staleEtag });
+        // No deterministic blob yet → legacy/list fallback (or a brand-new
+        // wallet); no CAS possible on the first write of the deterministic file.
+        const current = direct || (await getWalletProfile(wallet));
+
+        const updated = await updater(cloneWalletProfile(current));
+        const normalized = updated
+          ? stampProfileUpdatedAt(normalizeWalletProfile(updated))
+          : stampProfileUpdatedAt(cloneWalletProfile(EMPTY_WALLET_PROFILE));
+
+        try {
+          await writeWalletProfileBlob(wallet, normalized, { ifMatch: direct ? etag : null });
+        } catch (error) {
+          if (isEtagConflictError(error)) {
+            if (attempt < PROFILE_CAS_ATTEMPTS - 1) {
+              staleEtag = etag;
+              walletProfileReadCache.delete(wallet);
+              continue;
+            }
+            throw new Error("Profile write conflict — please retry.");
+          }
+          throw error;
+        }
+
+        walletProfileReadCache.delete(wallet);
+        dbReadCache = null;
+        return cloneWalletProfile(normalized);
+      }
+
+      throw new Error("Profile write conflict — please retry.");
     });
     walletWriteQueues.set(key, next);
 

--- a/tests/unit/helpers/blob-call-counter.js
+++ b/tests/unit/helpers/blob-call-counter.js
@@ -49,15 +49,34 @@ function blobNotFound() {
   return err;
 }
 
+function blobPreconditionFailed() {
+  const err = new Error("Precondition failed: ETag mismatch.");
+  err.name = "BlobPreconditionFailedError";
+  return err;
+}
+
 function createFakeBlob({ initialState = {} } = {}) {
   const state = new Map(Object.entries(initialState));
   const counts = { get: 0, put: 0, list: 0, del: 0, head: 0, copy: 0 };
+  const staleReadsByPath = new Map(); // pathname → how many next get()s serve the previous version
+  let etagCounter = 0;
 
   function setEntry(pathname, content, { uploadedAt } = {}) {
+    etagCounter += 1;
+    const previous = state.get(pathname) || null;
     state.set(pathname, {
       content: String(content),
       uploadedAt: uploadedAt || new Date().toISOString(),
+      etag: `etag-${etagCounter}`,
+      previous,
     });
+  }
+
+  // Emulate the Blob edge cache serving the pre-overwrite version: the next
+  // `count` get()s of this pathname return the previous entry (stale content
+  // AND stale etag), like a cached CDN response.
+  function primeStaleReads(pathname, count = 1) {
+    staleReadsByPath.set(pathname, count);
   }
 
   const fake = {
@@ -65,14 +84,20 @@ function createFakeBlob({ initialState = {} } = {}) {
       counts.get += 1;
       // Real blob storage ignores the query string (cache-busting `?fresh=`
       // from api/_lib/blob-read.js) — the fake must too.
-      const entry = state.get(String(pathname).split("?")[0]);
+      const cleanPath = String(pathname).split("?")[0];
+      let entry = state.get(cleanPath);
       if (!entry) {
         throw blobNotFound();
+      }
+      const staleLeft = staleReadsByPath.get(cleanPath) || 0;
+      if (staleLeft > 0 && entry.previous) {
+        staleReadsByPath.set(cleanPath, staleLeft - 1);
+        entry = entry.previous;
       }
       return {
         statusCode: 200,
         stream: makeReadableStream(entry.content),
-        blob: { etag: entry.uploadedAt },
+        blob: { etag: entry.etag || entry.uploadedAt },
       };
     },
     async put(pathname, content, opts = {}) {
@@ -83,6 +108,13 @@ function createFakeBlob({ initialState = {} } = {}) {
         throw new Error(
           `[fake blob] put() called with addRandomSuffix:true on ${pathname} — expected stable path`
         );
+      }
+      if (opts.ifMatch) {
+        const existing = state.get(pathname);
+        const currentEtag = existing ? existing.etag || existing.uploadedAt : null;
+        if (currentEtag !== opts.ifMatch) {
+          throw blobPreconditionFailed();
+        }
       }
       setEntry(pathname, content, { uploadedAt: new Date().toISOString() });
       return {
@@ -138,6 +170,7 @@ function createFakeBlob({ initialState = {} } = {}) {
     counts,
     state,
     setEntry,
+    primeStaleReads,
     resetCounts() {
       for (const key of Object.keys(counts)) counts[key] = 0;
     },
@@ -185,6 +218,7 @@ async function withFakeBlobEnv(run, { initialState = {} } = {}) {
       counts: handle.counts,
       state: handle.state,
       setEntry: handle.setEntry,
+      primeStaleReads: handle.primeStaleReads,
       resetCounts: handle.resetCounts,
       tempDir,
     });

--- a/tests/unit/profile-cas.test.js
+++ b/tests/unit/profile-cas.test.js
@@ -1,0 +1,75 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { withFakeBlobEnv } = require("./helpers/blob-call-counter");
+
+const WALLET = "CasWallet111111111111111111111111111111111";
+const PROFILE_PATH = `wallet-profiles/${WALLET}.json`;
+
+function petRecord(id) {
+  return {
+    id,
+    status: "completed",
+    name: id,
+    level: 1,
+    farmState: { active: false, startedAt: null, lastClaimedAt: null },
+  };
+}
+
+function startFarmMutator(petId) {
+  return (profile) => {
+    const pet = profile.characters.find((record) => record.id === petId);
+    pet.farmState = { active: true, startedAt: new Date().toISOString(), lastClaimedAt: null };
+    return profile;
+  };
+}
+
+// Reproduces the prod report: rapid farm-starts on several pets where one of
+// the reads is served stale (edge cache) — without CAS the stale-based write
+// silently dropped the previous farm-starts.
+test("updateWalletProfile CAS survives a stale read: no lost farm-starts", async () => {
+  await withFakeBlobEnv(async ({ store, primeStaleReads, counts }) => {
+    await store.saveWalletProfile(WALLET, {
+      characters: [petRecord("pet_1"), petRecord("pet_2"), petRecord("pet_3"), petRecord("pet_4")],
+      currency: { balance: 0, totalEarned: 0 },
+    });
+
+    await store.updateWalletProfile(WALLET, startFarmMutator("pet_1"));
+
+    // The next read serves the pre-farm-start version (stale CDN response).
+    primeStaleReads(PROFILE_PATH, 1);
+    await store.updateWalletProfile(WALLET, startFarmMutator("pet_2"));
+
+    await store.updateWalletProfile(WALLET, startFarmMutator("pet_3"));
+    await store.updateWalletProfile(WALLET, startFarmMutator("pet_4"));
+
+    const profile = await store.getWalletProfile(WALLET);
+    const farming = profile.characters.filter((record) => record.farmState.active).map((r) => r.id);
+    assert.deepEqual(farming.sort(), ["pet_1", "pet_2", "pet_3", "pet_4"]);
+    // The stale read must have caused at least one 412→retry put.
+    assert.ok(counts.put >= 6, `expected a CAS retry put, saw ${counts.put} puts`);
+  });
+});
+
+test("updateWalletProfile CAS gives up with an error instead of clobbering", async () => {
+  await withFakeBlobEnv(async ({ store, primeStaleReads }) => {
+    await store.saveWalletProfile(WALLET, {
+      characters: [petRecord("pet_1")],
+      currency: { balance: 0, totalEarned: 0 },
+    });
+    await store.updateWalletProfile(WALLET, startFarmMutator("pet_1"));
+
+    // Storage keeps serving the stale version forever → every CAS attempt
+    // conflicts; the write must FAIL loudly, never overwrite blindly.
+    primeStaleReads(PROFILE_PATH, 1000);
+    await assert.rejects(
+      store.updateWalletProfile(WALLET, (profile) => profile),
+      /conflict/i
+    );
+
+    primeStaleReads(PROFILE_PATH, 0); // stop emulating staleness for the final check
+    const profile = await store.getWalletProfile(WALLET);
+    // pet_1's farm-start survived untouched.
+    assert.equal(profile.characters[0].farmState.active, true);
+  });
+});


### PR DESCRIPTION
Fixes the prod report: rapid farm-starts on 4 pets → only 2 survived a refresh. Concurrent lambdas (or a stale read) doing read-modify-write of the profile blob clobbered each other's writes.

- profile writes now use \`put(..., { ifMatch: etag })\` — a write only lands if the profile hasn't changed since the updater read it
- on 412: re-read (skipping reads that still serve the stale etag), re-run the updater, up to 5 attempts; then fail loudly instead of overwriting
- test fake got real ETag/ifMatch semantics + a stale-read knob; 2 new tests reproduce the lost-update scenario
- 167/167 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)